### PR TITLE
Fix Sphinx docstring visibility and structure

### DIFF
--- a/docs/franka_mover.rst
+++ b/docs/franka_mover.rst
@@ -1,0 +1,4 @@
+.. automodule:: moveit2_sdk_python.franka_mover
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,9 @@ Welcome to MoveIt2 SDK Python's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-   modules
+   franka_mover
+   moveit2_sdk_python
+   try_node
 
 Indices and tables
 ==================
@@ -13,13 +15,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-Modules
-=======
-
-.. toctree::
-   :maxdepth: 1
-
-   moveit2_sdk_python/franka_mover
-   moveit2_sdk_python/moveit2_sdk_python
-   moveit2_sdk_python/try_node

--- a/docs/moveit2_sdk_python.rst
+++ b/docs/moveit2_sdk_python.rst
@@ -1,0 +1,4 @@
+.. automodule:: moveit2_sdk_python.moveit2_sdk_python
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/try_node.rst
+++ b/docs/try_node.rst
@@ -1,0 +1,4 @@
+.. automodule:: moveit2_sdk_python.try_node
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This commit updates the Sphinx documentation structure to ensure docstrings are correctly pulled from the Python modules and displayed in the generated HTML.

Key changes:
- Verified and confirmed `sys.path` in `docs/conf.py` is correct for module discovery.
- Created individual `.rst` files for each module (`franka_mover.rst`, `moveit2_sdk_python.rst`, `try_node.rst`) within the `docs` directory. These files use `automodule` with `:members:`, `:undoc-members:`, and `:show-inheritance:` to capture all documentation.
- Updated `docs/index.rst` to correctly reference these new module-specific `.rst` files in its `toctree`.
- Verified the Python package structure (`moveit2_sdk_python/moveit2_sdk_python/__init__.py`) is in place for proper module import by Sphinx.
- Outlined steps for local testing of the documentation build.